### PR TITLE
deps: using shared deps for iam proto dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,18 +84,6 @@
         <version>0.9.5-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-security-private-ca-v1beta1:current} -->
       </dependency>
       <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-iam-v1</artifactId>
-        <version>1.2.8</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-iam-v1</artifactId>
-        <version>1.2.7</version>
-      </dependency>
-
-
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>2.8.0</version>


### PR DESCRIPTION
Fixing the dependency convergence problem of https://github.com/googleapis/java-cloud-bom/pull/3917#issuecomment-1063310984 . Somehow in [this commit](https://github.com/googleapis/java-security-private-ca/commit/842d5ef95de31ea26a26dd576c4dd4d65fa9feec), java-security-private-ca is declaring its own version of iam proto versions, rather than relying on the shared dependencies BOM.

https://github.com/googleapis/java-shared-dependencies/blob/main/first-party-dependencies/pom.xml#L161 is where the shared dependencies BOM declares its iam proto version.

----

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-security-private-ca/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
